### PR TITLE
[Ne pas merger] Preview du profil SIRI 1.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "content/normes"]
 	path = content/normes
 	url = https://github.com/etalab/transport-normes
-	branch = main
+	branch = integration-profil-1.7


### PR DESCRIPTION
Dans:
- https://github.com/etalab/transport-normes/pull/32

J'ai adapté la totalité du profil SIRI 1.7 France (gelé) en markdown.

Je crée ici une branche temporaire pour faire en sorte que le contenu soit visualisable sous forme de preview sur le site (via Netlify).