### PR TITLE
Reconfiguration du site (1 repo NeTEx et 1 repo SIRI séparés)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,34 @@
 #!/usr/bin/env bash
 
-# not perfect, but better than nothing
+# stop processing on basic errors
 set -e
 
+# NOTE: temporarily freezing to the latest tag,
+# ultimately something more flexible with be introduced
+# (e.g. multi-version support, and first "automatic latest version")
+SIRI_VERSION=v1.7
+TEMP_FOLDER=tmp
+CONTENT_FOLDER=content/normes
+SIRI_REPO_NAME=transport-profil-siri-fr
+
 echo "Retrieving content via git..."
-git submodule update --init --remote content/normes
+git submodule update --init --remote $CONTENT_FOLDER
 
 echo "Removing legacy SIRI content..."
-rm -rf content/normes/SIRI
+rm -rf $CONTENT_FOLDER/SIRI
+
+echo "Cloning new SIRI content..."
+rm -rf $TEMP_FOLDER | true
+mkdir $TEMP_FOLDER && cd $TEMP_FOLDER
+git clone git@github.com:etalab/$SIRI_REPO_NAME.git
+cd $SIRI_REPO_NAME
+# just for debugging purposes
+git tag -l
+git checkout tags/$SIRI_VERSION
+cd ../..
+
+echo "Copying new SIRI content to the right place..."
+cp -r $TEMP_FOLDER/$SIRI_REPO_NAME/SIRI $CONTENT_FOLDER
 
 echo "Building site..."
 hugo --minify

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ rm -rf $CONTENT_FOLDER/SIRI
 echo "Cloning new SIRI content..."
 rm -rf $TEMP_FOLDER | true
 mkdir $TEMP_FOLDER && cd $TEMP_FOLDER
-git clone git@github.com:etalab/$SIRI_REPO_NAME.git
+git clone https://github.com/etalab/$SIRI_REPO_NAME.git
 cd $SIRI_REPO_NAME
 # just for debugging purposes
 git tag -l

--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,8 @@ set -e
 echo "Retrieving content via git..."
 git submodule update --init --remote content/normes
 
+echo "Removing legacy SIRI content..."
+rm -rf content/normes/SIRI
+
 echo "Building site..."
 hugo --minify

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# not perfect, but better than nothing
+set -e
+
+echo "Retrieving content via git..."
+git submodule update --init --remote content/normes
+
+echo "Building site..."
+hugo --minify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 # Ref: https://docs.netlify.com/configure-builds/file-based-configuration/
 
+[build]
 command = "echo TOML-configuration takes precedence && git submodule update --init --remote content/normes && hugo --minify"
 publish = "public"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+# Ref: https://docs.netlify.com/configure-builds/file-based-configuration/
+
+command = "echo TOML-configuration takes precedence && git submodule update --init --remote content/normes && hugo --minify"
+publish = "public"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 # Ref: https://docs.netlify.com/configure-builds/file-based-configuration/
 
 [build]
-command = "build.sh"
+command = "./build.sh"
 publish = "public"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 # Ref: https://docs.netlify.com/configure-builds/file-based-configuration/
 
 [build]
-command = "echo TOML-configuration takes precedence && git submodule update --init --remote content/normes && hugo --minify"
+command = "build.sh"
 publish = "public"


### PR DESCRIPTION
Je vais reconfigurer le site pour passer de:
- l'utilisation de 1 seul repo (http://github.com/etalab/transport-profil-netex-fr) pour NeTEx FR et SIRI FR (situation actuelle)
- à l'utilisation de 2 repo (le contenu SIRI FR a été dupliqué avec son historique sur https://github.com/etalab/transport-profil-siri-fr)

Voir:
- https://github.com/etalab/transport-profil-netex-fr/issues/65
- https://github.com/orgs/etalab/projects/35

### Étapes prévues

- [x] Rapporter la configuration Netlify (via leur web) dans une configuration Git
- [x] Extraire un script (bash ou autre) plutôt qu'un one-liner
- [x] Cloner https://github.com/etalab/transport-profil-siri-fr via le script (tag `v1.7` https://github.com/etalab/transport-profil-siri-fr/issues/16#issuecomment-2084682695)
- [x] Copier le contenu "au bon endroit"
- [x] Vérifier que la preview fonctionne
- [x] Créer une branche sur http://github.com/etalab/transport-profil-netex-fr où le contenu SIRI est supprimé (https://github.com/etalab/transport-profil-netex-fr/pull/83 mais ne pas la merger pour le moment)
- [ ] Faire une review ici
- [ ] Déployer
- [ ] Aller merger https://github.com/etalab/transport-profil-netex-fr/pull/83
