### PR TITLE
Page d'accueil : mise à jour description

### DIFF
--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -38,6 +38,10 @@
     margin-top: 24px;
 }
 
+.home-info ul {
+    padding-inline-start: 30px;
+}
+
 .post-entry {
     position: relative;
     margin-bottom: var(--gap);

--- a/config.yml
+++ b/config.yml
@@ -127,28 +127,39 @@ params:
               url: tags
 
     homeInfoParams:
-        Title: "Normes de transport en commun"
+        Title: "Normalisation des données multimodales"
         Content: |
-            ## Contexte
-            L'ouverture données statiques, dynamiques, observées et historiques des déplacements multimodaux est encadrée :
-            - au niveau européen, par le [règlement délégué (UE) 2017/1926](https://eur-lex.europa.eu/eli/reg_del/2017/1926/2024-03-04) de la Commission du 31 mai 2017 modifié par le règlement délégué (UE) 2024/490 de la Commission du 29 novembre 2023, dit "règlement MMTIS". Ce règlement complète la directive 2010/40/UE du Parlement européen et du Conseil en ce qui concerne la mise à disposition, dans l'ensemble de l'Union, de services d'informations sur les déplacements multimodaux.
-            - au niveau français, par les articles L. 1115-1 à L. 1115-7, D. 1115-1, R. 1115-2 à R. 1115-8 et D. 1115-9 à D. 1115-11 du code du transports, notamment créés ou modifiés par la loi n° 2019-1428 du 24 décembre 2019 d’orientation des mobilités, dites loi "LOM".
+          Conformément à l’arrêté du [4 mars 2022](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045382208), les spécifications référencées sur ce site correspondent aux versions officielles et en vigueur des profils français des normes européennes [NeTEx CEN/TS 16614](https://transmodel-cen.eu/index.php/netex/) pour la description de l'offre planifiée et des infrastructures, et [SIRI EN- CEN/TS 15531](https://transmodel-cen.eu/index.php/siri/) pour l'information en temps réel. Au regard du cadre règlementaire ci-dessous, les données à publier sur le Point d'accès national - transport.data.gouv.fr - doivent suivre a minima les profils européens ou les profils nationaux. Dans le cadre de la publication des données issues de la collecte des données d’accessibilité, l'utilisation du Profil NeTEx accessibilité France est obligatoire.
 
-            D'une part, les données existantes doivent être mises à disposition sur le point d’accès national des données multimodales en utilisant notamment les normes et spécifications techniques suivantes :
-            - Pour les données routières : le format défini par le règlement dit "RTTI" ;
-            - Pour les autres données :
-                - NeTEx CEN/TS 16614 et ses versions ultérieures, dit "NeTEx" ;
-                - SIRI CEN/TS 15531 et versions ultérieures, dit "SIRI" ;
-                - La norme établissant le modèle de données de référence pour le Transport Public Transmodel EN 12896 en l’absence de protocole d’échange de référence.
+          ## Cadre réglementaire
+          L'ouverture données statiques, dynamiques, observées et historiques des déplacements multimodaux est encadrée :
+          - au niveau européen
+            - par le [règlement délégué (UE) 2017/1926 (MMTIS)](https://eur-lex.europa.eu/legal-content/FR/TXT/?uri=CELEX:02017R1926-20240304) de la Commission du 31 mai 2017, modifié par le règlement délégué (UE) 2024/490 de la Commission du 29 novembre 2023 et complétant la directive 2010/40/UE du Parlement européen et du Conseil en ce qui concerne la mise à disposition, dans l'ensemble de l'Union, de services d'informations sur les déplacements multimodaux ;
+            - par le [règlement d’exécution (UE) 2026/253 (STI TEL)](https://eur-lex.europa.eu/legal-content/FR/TXT/?uri=CELEX:32026R0253) de la Commission du 6 février 2026 relatif à la spécification technique concernant le sous-système «télématique» du système ferroviaire de l’Union européenne pour l’interopérabilité du partage de données dans le transport ferroviaire ;
+          - au niveau français, par les articles [L. 1115-1 à L. 1115-7, D. 1115-1, R. 1115-2 à R. 1115-8 et D. 1115-9 à D. 1115-11 du code du transports](https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000023086525/LEGISCTA000039670430/#LEGISCTA000039670430), créés ou modifiés par la loi n° 2019-1428 du 24 décembre 2019 d’orientation des mobilités (LOM) et par la loi n° 2025-391 du 30 avril 2025 portant diverses dispositions d'adaptation au droit de l'Union européenne (DDADUE 2025).
 
-            D’autre part, les profils nationaux correspondent à des sous-ensembles de ces normes répondant aux besoins métiers. La mise à disposition des données selon une norme respecte a minima ces profils.
-            Conformément à l’arrêté du [4 mars 2022](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000045382208), les profils référencés ci-dessous correspondent aux versions officielles et en vigueur des profils à employer en France. 
-            
-            ## Descriptif
-            Les liens ci-dessous permettent d'accéder au format web au contenu des profils. Sur chacune des pages, il sera prochainement possible de télécharger une version pdf du document correspondant. Un espace [Github](https://github.com/etalab/transport-normes), hébergeant le contenu de ces documents, offre par ailleurs la possibilité d'explorer et d'exploiter leur contenu au format markdown.
+          La collecte des données d'accessibilité est encadrée au niveau français par encadrée par l'arrêté du [28 mai 2024](https://www.legifrance.gouv.fr/loda/id/LEGITEXT000049643437/2024-06-05#LEGITEXT000049643437).
 
-            ## Gouvernance
-            Les spécifications techniques sont élaborées et maintenues par le groupe de travail GT7 relatif à l'information voyageur (AFNOR BNTRA/CN03/GT7). Des commentaires peuvent toutefois être formulés sur les pages web de chaque profil, ainsi que directement sur [l'espace de commentaires Github](https://github.com/etalab/transport-normes/issues), permettant à la communauté de producteurs et de réutilisateurs de données de remonter des informations au groupe de travail.
+          Pour plus d'information :
+          - https://doc.transport.data.gouv.fr/le-point-d-acces-national/cadre-juridique
+          - https://www.ecologie.gouv.fr/politiques-publiques/partage-donnees-mobilite
+
+          ## Description
+          Les liens ci-dessous permettent d'accéder au format web au contenu des profils. Un espace Github hébergeant le contenu de ces documents pour chaque norme, offre par ailleurs la possibilité d'explorer et d'exploiter leur contenu au format markdown :
+          - [Github Profil France de NeTEx](https://github.com/etalab/transport-profil-netex-fr),
+          - [Github Profil France de SIRI](https://github.com/etalab/transport-profil-siri-fr)
+
+          Les profils France correspondent à une implémentation des normes européennes correspondant aux besoins métiers à l'échelle nationale.
+
+          ## Gouvernance
+          La publication des spécifications sur ce site les rendant de facto obligatoires en cas d’utilisation du profil France, ce site et son contenu relèvent de la responsabilité de la direction générale des transports, des infrastructures et des mobilités (DGITM). Le site est maintenu par l'équipe de transport.data.gouv.fr qui peut être contactée via ce [formulaire](https://transport.data.gouv.fr/#mail_form).
+
+          Les spécifications techniques sont élaborées et maintenues par le groupe de travail GT7 relatif à l'information voyageur (AFNOR BNTRA/CN03/GT7). Des commentaires peuvent être formulés sur les pages web de chaque profil, ainsi que directement sur les espace de commentaires Github :
+          - [Espace commentaires Profil France de NeTEx](https://github.com/etalab/transport-profil-netex-fr/issues)
+          - [Espace commentaires Profil France de SIRI](https://github.com/etalab/transport-profil-siri-fr/issues)
+          Ces espaces permettent à la communauté de producteurs et de réutilisateurs de données de remonter des besoins ou des problèmes directement au groupe de travail.
+
+          Pour des raisons techniques, seule la version actuelle peut être rendue visible sur le site. Nous vous encourageons donc à visiter les repositoires ou à rejoindre le GT7 afin de suivre les évolutions.
     socialIcons:
         - name: github
           url: "https://github.com/etalab/transport-normes"


### PR DESCRIPTION
Mise à jour du texte tel que proposé dans #24. Correction de l'affichage des listes pour respecter la structure du propos :

<img width="2256" height="4541" alt="image" src="https://github.com/user-attachments/assets/035810f7-a9e2-43a5-b78f-8a4371156a18" />

closes #24