### PR TITLE
Outil pour naviguer les changements surlignés

### DIFF
--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -81,3 +81,40 @@ pre:hover .copy-code {
 .post-content h7 {
     font-size: 12px;
 }
+
+mark.focused, .hl.focused, .mark.focused {
+    background-color: color-mix(in oklch, yellow, orange);
+    outline: 1px solid orange;
+}
+
+#explorer {
+    visibility: hidden;
+    background: rgb(from white r g b / 0.95);
+    position: fixed;
+    bottom: 60px;
+    left: 30px;
+    z-index: 99;
+    display: flex;
+    gap: 15px;
+    align-items: center;
+}
+
+#explorer.visible {
+    visibility: visible;
+}
+
+#explorer button {
+    color: var(--secondary);
+    background: var(--tertiary);
+    height: 42px;
+    border-radius: 64px;
+    padding: 0 15px;
+}
+
+#explorer button:hover {
+    color: var(--primary);
+}
+
+#explorer span {
+    font-weight: 600;
+}

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -85,3 +85,16 @@ tr:has(mark), tr:has(span.hl) {
 .post-content h7 {
     font-size: 12px;
 }
+
+.post-content th, .post-content td {
+    vertical-align: top;
+}
+
+.post-content.post-content table td, .post-content.post-content table th {
+    padding: 4px 6px;
+    min-width: 40px;
+}
+
+td > p:last-child {
+    margin-bottom: 0;
+}

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -66,7 +66,7 @@ pre:hover .copy-code {
     display: block;
 }
 
-.hl {
+mark, .hl {
     background-color: rgb(255, 255, 152);
 }
 
@@ -74,7 +74,7 @@ pre:hover .copy-code {
     background-color: rgb(98, 255, 50);
 }
 
-.hl_delete {
+.main .post-content del, .hl_delete {
     background-color: rgb(0, 225, 255);
 }
 

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -70,6 +70,10 @@ mark, .hl {
     background-color: rgb(255, 255, 152);
 }
 
+tr:has(mark), tr:has(span.hl) {
+    background-color: color-mix(rgb(255, 255, 152), white 80%);
+}
+
 .hl_france {
     background-color: rgb(98, 255, 50);
 }

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -74,6 +74,14 @@ tr:has(mark), tr:has(span.hl) {
     background-color: color-mix(rgb(255, 255, 152), white 80%);
 }
 
+tr:hover td {
+    background-color: color-mix(lightgrey, white 80%);
+}
+
+tr:hover:has(mark) td, tr:hover:has(span.hl) td {
+    background-color: color-mix(rgb(255, 255, 152), white 40%);
+}
+
 .hl_france {
     background-color: rgb(98, 255, 50);
 }

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -106,3 +106,40 @@ tr:hover:has(mark) td, tr:hover:has(span.hl) td {
 td > p:last-child {
     margin-bottom: 0;
 }
+
+mark.focused, .hl.focused, .mark.focused {
+    background-color: color-mix(in oklch, yellow, orange);
+    outline: 1px solid orange;
+}
+
+#explorer {
+    visibility: hidden;
+    background: rgb(from white r g b / 0.95);
+    position: fixed;
+    bottom: 60px;
+    left: 30px;
+    z-index: 99;
+    display: flex;
+    gap: 15px;
+    align-items: center;
+}
+
+#explorer.visible {
+    visibility: visible;
+}
+
+#explorer button {
+    color: var(--secondary);
+    background: var(--tertiary);
+    height: 42px;
+    border-radius: 64px;
+    padding: 0 15px;
+}
+
+#explorer button:hover {
+    color: var(--primary);
+}
+
+#explorer span {
+    font-weight: 600;
+}

--- a/build.sh
+++ b/build.sh
@@ -61,4 +61,4 @@ echo "Copying cloned SIRI content to the right place..."
 cp -r $LOCAL_TEMP_FOLDER/$SIRI_REPO_NAME/SIRI $CONTENT_FOLDER
 
 echo "Building site..."
-hugo --minify
+hugo --minify --baseURL "$DEPLOY_PRIME_URL"

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,0 +1,65 @@
+<div id="explorer">
+  <button id="explorer-previous" type="button">&lt;</button>
+  <span id="explorer-counter"></span>
+  <button id="explorer-next" type="button">&gt;</button>
+</div>
+
+<script>
+    // Set this localStorage key to enable the changes explorer:
+    const enabled = window.localStorage.getItem("explorer.enabled");
+
+    const previous = document.getElementById("explorer-previous");
+    const next = document.getElementById("explorer-next");
+    const counter = document.getElementById("explorer-counter");
+    const changes = Array.from(document.querySelectorAll("mark, .mark, .hl")).slice(1);
+    var currentIndex = 0;
+
+    function scrollIntoViewWithOffset(element, offset) {
+      window.scrollTo({
+        behavior: 'smooth',
+        top:
+          element.getBoundingClientRect().top -
+          document.body.getBoundingClientRect().top -
+          offset,
+      })
+    }
+
+    function explore(target) {
+        changes[currentIndex].classList.remove("focused");
+        if (target == previous) {
+            currentIndex -= 1;
+        } else {
+            currentIndex += 1;
+        }
+        if (currentIndex < 0) {
+            currentIndex = changes.length - 1;
+        }
+        if (currentIndex == changes.length) {
+            currentIndex = 0;
+        }
+        counter.innerText = `${currentIndex + 1} / ${changes.length}`;
+        changes[currentIndex].classList.add("focused");
+        scrollIntoViewWithOffset(changes[currentIndex], 300);
+    }
+
+    previous.addEventListener("click", event => explore(event.currentTarget));
+    next.addEventListener("click", event => explore(event.currentTarget));
+
+    document.addEventListener("keyup", (event) => {
+      switch (event.key) {
+        case "ArrowRight":
+          explore(next);
+          break;
+
+        case "ArrowLeft":
+          explore(previous);
+          break;
+      }
+    })
+
+    counter.innerText = `${currentIndex + 1} / ${changes.length}`;
+
+    if (enabled && changes.length > 0) {
+        explorer.classList.add("visible");
+    }
+</script>


### PR DESCRIPTION
Proposition d'outil pour explorer rapidement les changements du profil France par l'interface en bas à gauche ou via le clavier (flèches gauches et droites du clavier).

Aperçu :

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/0127d56e-14fe-418d-9e1c-cfb3f2c85d11" />

Pour l'instant c'est masqué par un feature flag dans le localStorage ;

```javascript
window.localStorage.setItem("explorer.enabled", true)
```