### PR TITLE
Amélioration style des tableaux

### DIFF
--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -85,3 +85,16 @@ tr:has(mark), tr:has(span.hl) {
 .post-content h7 {
     font-size: 12px;
 }
+
+.post-content th, .post-content td {
+    vertical-align: top;
+}
+
+.post-content.post-content table td, .post-content.post-content table th {
+    padding: 4px 6px;
+    min-width: 40px;
+}
+
+td > p:last-child {
+    margin-bottom: 0;
+}

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -66,7 +66,7 @@ pre:hover .copy-code {
     display: block;
 }
 
-.hl {
+mark, .hl {
     background-color: rgb(255, 255, 152);
 }
 
@@ -74,7 +74,7 @@ pre:hover .copy-code {
     background-color: rgb(98, 255, 50);
 }
 
-.hl_delete {
+.main .post-content del, .hl_delete {
     background-color: rgb(0, 225, 255);
 }
 

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -70,6 +70,10 @@ mark, .hl {
     background-color: rgb(255, 255, 152);
 }
 
+tr:has(mark), tr:has(span.hl) {
+    background-color: color-mix(rgb(255, 255, 152), white 80%);
+}
+
 .hl_france {
     background-color: rgb(98, 255, 50);
 }

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -74,6 +74,14 @@ tr:has(mark), tr:has(span.hl) {
     background-color: color-mix(rgb(255, 255, 152), white 80%);
 }
 
+tr:hover td {
+    background-color: color-mix(lightgrey, white 80%);
+}
+
+tr:hover:has(mark) td, tr:hover:has(span.hl) td {
+    background-color: color-mix(rgb(255, 255, 152), white 40%);
+}
+
 .hl_france {
     background-color: rgb(98, 255, 50);
 }

--- a/build.sh
+++ b/build.sh
@@ -61,4 +61,4 @@ echo "Copying cloned SIRI content to the right place..."
 cp -r $LOCAL_TEMP_FOLDER/$SIRI_REPO_NAME/SIRI $CONTENT_FOLDER
 
 echo "Building site..."
-hugo --minify
+hugo --minify --baseURL "$DEPLOY_PRIME_URL"


### PR DESCRIPTION
- les cellules sont alignées verticalement en haut
- j'ai revu les marges des cellules
- les colonnes n'ont plus de largeur minimale pour ne pas gaspiller l'espace disponible
- les lignes qui contiennent une balise `<mark>` sont soulignés en jaune pale pour faciliter la lecture
- au survol du tableau, la ligne couramment survolée a une couleur de fond différente (pas visible sur le screenshot) ; ici encore pour faciliter la lecture

| Avant | Après |
| ----- | ----- |
| <img alt="Avant" src="https://github.com/user-attachments/assets/cecc4572-833d-4209-932f-8d6e70613318" /> | <img alt="Après" src="https://github.com/user-attachments/assets/065ce169-22f6-46e9-ad2c-470824965c9b" /> |
